### PR TITLE
Search results

### DIFF
--- a/src/main/java/se/myhappyplants/client/controller/SearchTabPaneController.java
+++ b/src/main/java/se/myhappyplants/client/controller/SearchTabPaneController.java
@@ -154,6 +154,7 @@ public class SearchTabPaneController {
                         progressIndicator.progressProperty().unbind();
                         progressIndicator.setProgress(100);
                         btnSearch.setDisable(false);
+                        Platform.runLater(() -> listViewResult.getItems().clear());
                         return;
                     }
                     Platform.runLater(() -> showResultsOnPane());

--- a/src/main/java/se/myhappyplants/client/controller/SearchTabPaneController.java
+++ b/src/main/java/se/myhappyplants/client/controller/SearchTabPaneController.java
@@ -149,19 +149,13 @@ public class SearchTabPaneController {
             if (apiResponse != null) {
                 if (apiResponse.isSuccess()) {
                     searchResults = apiResponse.getPlantArray();
-                    if (searchResults.size() == 0) {
-                        Platform.runLater(() -> txtNbrOfResults.setText(0 + " results"));
+                    Platform.runLater(() -> txtNbrOfResults.setText(searchResults.size() + " results"));
+                    if(searchResults.size() == 0) {
+                        progressIndicator.progressProperty().unbind();
+                        progressIndicator.setProgress(100);
                         btnSearch.setDisable(false);
-                        Text text = (Text) progressIndicator.lookup(".percentage");
-                        if(text.getText().equals("90%") || text.getText().equals("Done")){
-                            text.setText("Done");
-                            progressIndicator.setPrefWidth(text.getLayoutBounds().getWidth());
-                        }
-                        searchResults.clear();
                         return;
                     }
-                    String nbrOfResults = String.valueOf(searchResults.size());
-                    Platform.runLater(() -> txtNbrOfResults.setText(nbrOfResults + " results"));
                     Platform.runLater(() -> showResultsOnPane());
                 }
             }


### PR DESCRIPTION
Jag har fixat så att det inte längre blir ett exception i SearchPlantPane om användaren:

1. Söker på en planta som finns
2. Sedan söker på en planta som inte finns. 

Nu blir också resultatlistan helt tom när användaren söker på något som inte finns, trots att sökningen innan gav resultat. 